### PR TITLE
ref(Dockerfile): switch to alpine-based image

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,6 +1,7 @@
-FROM python:3.5
-RUN apt-get upgrade && apt-get install -y \ 
-  && curl -sSL https://raw.githubusercontent.com/pypa/pip/7.1.2/contrib/get-pip.py | python - \
-  && pip install flake8 
+FROM python:3.5-alpine
 
-
+RUN pip install \
+    coverage==4.0.3 \
+    codecov==1.6.3 \
+    flake8==2.5.4 \
+    requests-mock==0.7.0


### PR DESCRIPTION
This reduces the size of the Docker image from 701.5 to 99 MB, while adding the `dev_requirements.txt` packages from deis/controller.

See also deis/docker-go-dev#25.
